### PR TITLE
[gretl] Add additional CA certificate to Jenkins

### DIFF
--- a/gretl/README.md
+++ b/gretl/README.md
@@ -149,12 +149,12 @@ stringData:
 Place your additional CA certificate in a separate folder.
 Then create a ConfigMap from it:
 ```
-oc create --dry-run=client configmap jenkins-ca-bundle --from-file=ca-bundle.crt=mycertificatefilename.crt -o yaml > jenkins-ca-bundle.yaml
+oc create --dry-run=client configmap jenkins-ca-certificates --from-file=ca-certificates.crt=mycertificatefilename.crt -o yaml > jenkins-ca-certificates.yaml
 ```
 Then run
 ```
-oc apply -f jenkins-ca-bundle.yaml -n my-namespace
-oc label configmap jenkins-ca-bundle app=gretl-platform -n my-namespace
+oc apply -f jenkins-ca-certificates.yaml -n my-namespace
+oc label configmap jenkins-ca-certificates app=gretl-platform -n my-namespace
 ```
 
 ## Apply template

--- a/gretl/README.md
+++ b/gretl/README.md
@@ -149,12 +149,12 @@ stringData:
 Place your additional CA certificate in a separate folder.
 Then create a ConfigMap from it:
 ```
-oc create --dry-run=client configmap jenkins-ca-certificates --from-file=ca-certificates.crt=mycertificatefilename.crt -o yaml > jenkins-ca-certificates.yaml
+oc create --dry-run=client configmap gretl-jenkins-ca-certificates --from-file=ca-certificates.crt=mycertificatefilename.crt -o yaml > gretl-jenkins-ca-certificates.yaml
 ```
 Then run
 ```
-oc apply -f jenkins-ca-certificates.yaml -n my-namespace
-oc label configmap jenkins-ca-certificates app=gretl-platform -n my-namespace
+oc apply -f gretl-jenkins-ca-certificates.yaml -n my-namespace
+oc label configmap gretl-jenkins-ca-certificates app=gretl-platform -n my-namespace
 ```
 
 ## Apply template

--- a/gretl/README.md
+++ b/gretl/README.md
@@ -144,6 +144,18 @@ stringData:
   password: myAccessToken
 ```
 
+## Create ConfigMap containing an additional CA certificate
+
+Place your additional CA certificate in a separate folder.
+Then create a ConfigMap from it:
+```
+oc create --dry-run=client configmap jenkins-ca-bundle --from-file=ca-bundle.crt=mycertificatefilename.crt -o yaml > jenkins-ca-bundle.yaml
+```
+Then run
+```
+oc apply -f jenkins-ca-bundle.yaml -n my-namespace
+oc label configmap jenkins-ca-bundle app=gretl-platform -n my-namespace
+```
 
 ## Apply template
 

--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -201,7 +201,7 @@ objects:
           - name: configuration-as-code-volume
             mountPath: /opt/configuration-as-code
             readOnly: true
-          - name: jenkins-ca-certificates-volume
+          - name: gretl-jenkins-ca-certificates-volume
             mountPath: /etc/pki/ca-trust/source/anchors
             readOnly: true
         ## Define the required volumes
@@ -212,9 +212,9 @@ objects:
         - name: configuration-as-code-volume
           configMap:
             name: configuration-as-code
-        - name: jenkins-ca-certificates-volume
+        - name: gretl-jenkins-ca-certificates-volume
           configMap:
-            name: jenkins-ca-certificates
+            name: gretl-jenkins-ca-certificates
     triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -201,6 +201,9 @@ objects:
           - name: configuration-as-code-volume
             mountPath: /opt/configuration-as-code
             readOnly: true
+          - name: jenkins-ca-bundle-volume
+            mountPath: /etc/pki/ca-trust/source/anchors
+            readOnly: true
         ## Define the required volumes
         volumes:
         - name: ${APPNAME}-data
@@ -209,6 +212,9 @@ objects:
         - name: configuration-as-code-volume
           configMap:
             name: configuration-as-code
+        - name: jenkins-ca-bundle-volume
+          configMap:
+            name: jenkins-ca-bundle
     triggers:
     - type: ConfigChange
     - type: ImageChange

--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -201,7 +201,7 @@ objects:
           - name: configuration-as-code-volume
             mountPath: /opt/configuration-as-code
             readOnly: true
-          - name: jenkins-ca-bundle-volume
+          - name: jenkins-ca-certificates-volume
             mountPath: /etc/pki/ca-trust/source/anchors
             readOnly: true
         ## Define the required volumes
@@ -212,9 +212,9 @@ objects:
         - name: configuration-as-code-volume
           configMap:
             name: configuration-as-code
-        - name: jenkins-ca-bundle-volume
+        - name: jenkins-ca-certificates-volume
           configMap:
-            name: jenkins-ca-bundle
+            name: jenkins-ca-certificates
     triggers:
     - type: ConfigChange
     - type: ImageChange


### PR DESCRIPTION
Auf diese Weise kann man z.B. ein internes Root-Zertifikat in Jenkins verfügbar machen.

Details dazu:
Als Docker Entrypoint des Jenkins-Images wird `/usr/libexec/s2i/run` ausgeführt. Hier wird u.a. folgender Code ausgeführt:
```
# update system java keystore with custom ca bundle from jenkins-trust-ca-bundle configmap
# ca bundle is injected by network operator via the configmap jenkins-trusted-ca-bundle
# see certificate-injection-using-operators_configuring-a-custom-pki in the documentation
system_ca_bundle_crt="/etc/pki/ca-trust/source/anchors/ca-bundle.crt"
if [ -f "${system_ca_bundle_crt}" ]; then
  /usr/bin/p11-kit extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth ${JENKINS_HOME}/ca-anchors-keystore
fi
```
D.h. wenn man das zusätzliche Zertifikat in einer ConfigMap platziert und unter `/etc/pki/ca-trust/source/anchors/ca-bundle.crt` mountet, wird es (offenbar zusammen mit den bereits bestehenden Zertifikaten) unter `${JENKINS_HOME}/ca-anchors-keystore` abgelegt. (Und Jenkins wird dann beim Start zusätzlich die Option `${JENKINS_HOME}/ca-anchors-keystore` übergeben.)

Dokumentiert unter https://docs.openshift.com/container-platform/4.10/networking/configuring-a-custom-pki.html#certificate-injection-using-operators_configuring-a-custom-pki (wobei es hier evtl. um einen leicht anders gelagerten Fall geht).