### PR TITLE
[gretl] Place secrets in gradle.properties file

### DIFF
--- a/gretl/README.md
+++ b/gretl/README.md
@@ -171,7 +171,7 @@ oc label configmap gretl-jenkins-ca-certificates app=gretl-platform -n my-namesp
 Place your additional SSH private key in a separate folder.
 Then create a secret from it:
 ```
-oc create --dry-run=client secret general gretl-privatekeys --from-file=id_rsa=myprivatekeyfilename -o yaml > gretl-privatekeys.yaml
+oc create --dry-run=client secret generic gretl-privatekeys --from-file=id_rsa=myprivatekeyfilename -o yaml > gretl-privatekeys.yaml
 ```
 Then run
 ```

--- a/gretl/README.md
+++ b/gretl/README.md
@@ -13,6 +13,9 @@ oc create secret docker-registry dockerhub-pull-secret --docker-username=xy --do
 oc secrets link default dockerhub-pull-secret --for=pull -n my-namespace
 oc secrets link jenkins dockerhub-pull-secret --for=pull -n my-namespace
 ```
+(Please note that the last command can be run successfully
+only after the _jenkins_ service account has been created.
+See a little further down in this document.)
 
 Grant permissions for deploying the app
 from a Jenkins instance running in a different namespace (optional);
@@ -98,6 +101,11 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: jenkins
+```
+
+Now link the _dockerhub-pull-secret_ to the _jenkins_ service account as well:
+```
+oc secrets link jenkins dockerhub-pull-secret --for=pull -n my-namespace
 ```
 
 ## Create Persistent Volume Claim

--- a/gretl/README.md
+++ b/gretl/README.md
@@ -46,10 +46,11 @@ metadata:
   labels:
     app: gretl-platform
 stringData:
-  ORG_GRADLE_PROJECT_dbUserEdit: myusername1
-  ORG_GRADLE_PROJECT_dbPwdEdit: mypassword1
-  ORG_GRADLE_PROJECT_dbUserPub: myusername2
-  ORG_GRADLE_PROJECT_dbPwdPub: mypassword2
+  gradle.properties: |-
+    dbUserEdit=myusername1
+    dbPwdEdit=mypassword1
+    dbUserPub=myusername2
+    dbPwdPub=mypassword2
 ```
 
 ## Create ConfigMap

--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -358,8 +358,14 @@ objects:
           envFrom:
             - configMapRef:
                 name: gretl-resources
-            - secretRef:
-                name: gretl-secrets
+          volumeMounts:
+            - name: gretl-secrets-volume
+              mountPath: /home/gradle/.gradle/gradle.properties
+              subPath: gradle.properties
+        volumes:
+          - name: gretl-secrets-volume
+            secret:
+              secretName: gretl-secrets
         </yaml>
       </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
 - apiVersion: v1
@@ -441,8 +447,14 @@ objects:
           envFrom:
             - configMapRef:
                 name: gretl-resources
-            - secretRef:
-                name: gretl-secrets
+          volumeMounts:
+            - name: gretl-secrets-volume
+              mountPath: /home/gradle/.gradle/gradle.properties
+              subPath: gradle.properties
+        volumes:
+          - name: gretl-secrets-volume
+            secret:
+              secretName: gretl-secrets
         </yaml>
       </org.csanchez.jenkins.plugins.kubernetes.PodTemplate>
 parameters:


### PR DESCRIPTION
Instead of passing credentials as environment variables, place them in a `gradle.properties` file and mount it at `~/.gradle`.

Unfortunately this mount is defined in a different way (YAML) than the _gretl-privatekeys_ mount (Jenkins Kubernetes plugin XML configuration). It probably makes sense to define the _gretl-privatekeys_ mount using YAML as well one day.