### PR TITLE
[gretl] Set Jenkins admin e-mail using CasC plugin

### DIFF
--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -28,6 +28,9 @@ objects:
     configuration-as-code.yaml: |
       jenkins:
         scmCheckoutRetryCount: 1
+      unclassified:
+        location:
+          adminAddress: ${JENKINS_ADMIN_EMAIL_ADDRESS}
       jobs:
         - script: |
             job('gretl-job-generator') {
@@ -520,6 +523,10 @@ parameters:
   displayName: Path or URL to Configuration as Code config file
   description: Path or URL to the config file for the Jenkins Configuration as Code plugin.
   value: /opt/configuration-as-code/configuration-as-code.yaml
+- name: JENKINS_ADMIN_EMAIL_ADDRESS
+  displayName: Jenkins administrator e-mail address
+  description: E-mail address that appears in the FROM header in e-mails sent by Jenkins
+  value: noreply@localhost
 - name: JENKINS_PVC_NAME
   description: Name of the PVC for storing the Jenkins config and the jobs
   required: true

--- a/gretl/gretl_development.params
+++ b/gretl/gretl_development.params
@@ -11,6 +11,7 @@ HOSTNAME=
 ENABLE_OAUTH=true
 # Set to true when installing/updating plugins, set to false for faster Jenkins startup:
 OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS=true
+JENKINS_ADMIN_EMAIL_ADDRESS=noreply@localhost
 JENKINS_PVC_NAME=jenkins
 JENKINS_AGENT_IMAGE_TAG=4.10
 JENKINS_AGENT_IMAGE_IMPORT_POLICY_SCHEDULED=true

--- a/gretl/gretl_integration.params
+++ b/gretl/gretl_integration.params
@@ -11,6 +11,7 @@ HOSTNAME=gretl-i.so.ch
 ENABLE_OAUTH=false
 # Set to true when installing/updating plugins, set to false for faster Jenkins startup:
 OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS=false
+JENKINS_ADMIN_EMAIL_ADDRESS=GRETL Integration <noreply@gretl-i.agi.so.ch>
 JENKINS_PVC_NAME=jenkins2
 JENKINS_AGENT_IMAGE_TAG=4.10
 JENKINS_AGENT_IMAGE_IMPORT_POLICY_SCHEDULED=true

--- a/gretl/gretl_production.params
+++ b/gretl/gretl_production.params
@@ -11,6 +11,7 @@ HOSTNAME=gretl.so.ch
 ENABLE_OAUTH=false
 # Set to true when installing/updating plugins, set to false for faster Jenkins startup:
 OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS=false
+JENKINS_ADMIN_EMAIL_ADDRESS=GRETL <noreply@gretl.agi.so.ch>
 JENKINS_PVC_NAME=jenkins2
 JENKINS_AGENT_IMAGE_TAG=4.10
 JENKINS_AGENT_IMAGE_IMPORT_POLICY_SCHEDULED=true

--- a/gretl/gretl_test.params
+++ b/gretl/gretl_test.params
@@ -11,6 +11,7 @@ HOSTNAME=gretl-t.so.ch
 ENABLE_OAUTH=false
 # Set to true when installing/updating plugins, set to false for faster Jenkins startup:
 OVERRIDE_PV_PLUGINS_WITH_IMAGE_PLUGINS=false
+JENKINS_ADMIN_EMAIL_ADDRESS=GRETL Test <noreply@gretl-t.agi.so.ch>
 JENKINS_PVC_NAME=jenkins2
 JENKINS_AGENT_IMAGE_TAG=4.10
 JENKINS_AGENT_IMAGE_IMPORT_POLICY_SCHEDULED=true


### PR DESCRIPTION
Since the upgrade to Jenkins image tag 4.10 the admin e-mail address is reset to a default value after Jenkins restart. This PR fixes this by setting the admin e-mail address using the _Jenkins Configuration as Code_ plugin. It is already in use for other Jenkins config.