### PR TITLE
Undo DNS resolutions over TCP

### DIFF
--- a/gretl/gretl.yaml
+++ b/gretl/gretl.yaml
@@ -341,9 +341,6 @@ objects:
         <nodeProperties/>
         <yaml>
       spec:
-        dnsConfig:
-          options:
-            - name: use-vc
         containers:
         - name: jnlp
           resources:
@@ -433,9 +430,6 @@ objects:
         <nodeProperties/>
         <yaml>
       spec:
-        dnsConfig:
-          options:
-            - name: use-vc
         containers:
         - name: jnlp
           resources:


### PR DESCRIPTION
Revert "[gretl] Try RES_USEVC (force the use of TCP for DNS resolutions)". This reverts commit b6b527dc9074e7d570924c03a1d2513333171b45, as that change turned out to be unnecessary.